### PR TITLE
Bugfix: don't check convergence rate when m=1 in auto solver switching

### DIFF
--- a/linux-ubuntu20.04-x86_64/gcc-9.4.0/double/cvVdp_auto_nls.out
+++ b/linux-ubuntu20.04-x86_64/gcc-9.4.0/double/cvVdp_auto_nls.out
@@ -15,42 +15,42 @@ Van der Pol oscillator (CVODE):
    60.000000    1.482963   -0.012303
    70.000000    1.341053   -0.016812
    80.000000    1.077359   -0.064238
-   90.000000   -1.939564    0.007024
-  100.000000   -1.866710    0.007511
-  110.000000   -1.788379    0.008131
-  120.000000   -1.702875    0.008958
-  130.000000   -1.607310    0.010115
-  140.000000   -1.497104    0.012054
-  150.000000   -1.359614    0.015824
-  160.000000   -1.136277    0.038618
-  170.000000    1.948365   -0.006968
-  180.000000    1.876306   -0.007444
-  190.000000    1.798801   -0.008046
-  200.000000    1.714318   -0.008838
-  210.000000    1.620395   -0.009945
-  220.000000    1.512739   -0.011684
-  230.000000    1.379580   -0.015280
-  240.000000    1.176470   -0.030506
-  250.000000   -1.956787    0.006880
+   90.000000   -1.939912    0.007020
+  100.000000   -1.867227    0.007509
+  110.000000   -1.789033    0.008128
+  120.000000   -1.703470    0.008951
+  130.000000   -1.607941    0.010116
+  140.000000   -1.498021    0.011978
+  150.000000   -1.360920    0.015760
+  160.000000   -1.137088    0.038566
+  170.000000    1.948506   -0.006968
+  180.000000    1.876282   -0.007442
+  190.000000    1.798780   -0.008043
+  200.000000    1.714359   -0.008832
+  210.000000    1.620444   -0.009950
+  220.000000    1.512408   -0.011713
+  230.000000    1.379486   -0.015155
+  240.000000    1.178377   -0.030187
+  250.000000   -1.957054    0.006916
    -----------------------------------
-Current time                  = 250.000894103839
-Steps                         = 4050
-Error test fails              = 258
-NLS step fails                = 3
+Current time                  = 254.054762789441
+Steps                         = 2937
+Error test fails              = 165
+NLS step fails                = 5
 Constraint fails              = 0
 Constraint corrections        = 0
 Initial step size             = 2.04083345024543e-07
-Last step size                = 0.00164224543845974
-Current step size             = 0.00164224543845974
-Last method order             = 1
-Current method order          = 1
+Last step size                = 4.71185576421916
+Current step size             = 4.71185576421916
+Last method order             = 2
+Current method order          = 2
 Stab. lim. order reductions   = 0
-RHS fn evals                  = 4493
-NLS iters                     = 4490
-NLS fails                     = 14
-NLS iters per step            = 1.10864197530864
-LS setups                     = 73
-Jac fn evals                  = 15
+RHS fn evals                  = 3629
+NLS iters                     = 3626
+NLS fails                     = 15
+NLS iters per step            = 1.23459312223357
+LS setups                     = 82
+Jac fn evals                  = 14
 LS RHS fn evals               = 0
 Prec setup evals              = 0
 Prec solves                   = 0
@@ -59,7 +59,7 @@ LS fails                      = 0
 Jac-times setups              = 0
 Jac-times evals               = 0
 LS iters per NLS iter         = 0
-Jac evals per NLS iter        = 0.00334075723830735
+Jac evals per NLS iter        = 0.00386100386100386
 Prec evals per NLS iter       = 0
 Root fn evals                 = 0
-   Auto nonlinear solver iteration totals: newton = 299, fixed-point = 4191
+   Auto nonlinear solver iteration totals: newton = 329, fixed-point = 3297

--- a/linux-ubuntu20.04-x86_64/gcc-9.4.0/single/cvVdp_auto_nls.out
+++ b/linux-ubuntu20.04-x86_64/gcc-9.4.0/single/cvVdp_auto_nls.out
@@ -14,43 +14,43 @@ Van der Pol oscillator (CVODE):
    50.000000    1.595920   -0.010257
    60.000000    1.483922   -0.012355
    70.000000    1.341693   -0.016616
-   80.000000    1.079790   -0.062503
-   90.000000   -1.940024    0.007021
-  100.000000   -1.867256    0.007508
-  110.000000   -1.789044    0.008129
-  120.000000   -1.703525    0.008957
-  130.000000   -1.608064    0.010140
-  140.000000   -1.497887    0.012017
-  150.000000   -1.360726    0.015792
-  160.000000   -1.136887    0.038378
-  170.000000    1.948271   -0.006969
-  180.000000    1.876072   -0.007443
-  190.000000    1.798580   -0.008044
-  200.000000    1.714118   -0.008833
-  210.000000    1.620151   -0.009953
-  220.000000    1.512098   -0.011722
-  230.000000    1.379306   -0.015108
-  240.000000    1.182084   -0.029392
-  250.000000   -1.957928    0.006910
+   80.000000    1.079845   -0.062451
+   90.000000   -1.940107    0.007019
+  100.000000   -1.867381    0.007505
+  110.000000   -1.789212    0.008124
+  120.000000   -1.703785    0.008947
+  130.000000   -1.608487    0.010111
+  140.000000   -1.498319    0.011944
+  150.000000   -1.361540    0.015949
+  160.000000   -1.137326    0.038412
+  170.000000    1.948831   -0.006971
+  180.000000    1.876743   -0.007441
+  190.000000    1.799411   -0.008041
+  200.000000    1.714773   -0.008837
+  210.000000    1.620947   -0.009940
+  220.000000    1.513198   -0.011693
+  230.000000    1.381184   -0.015061
+  240.000000    1.183934   -0.029361
+  250.000000   -1.958128    0.006909
    -----------------------------------
-Current time                  = 251.495
-Steps                         = 1101
-Error test fails              = 56
-NLS step fails                = 12
+Current time                  = 255.734
+Steps                         = 3360
+Error test fails              = 223
+NLS step fails                = 3
 Constraint fails              = 0
 Constraint corrections        = 0
 Initial step size             = 7.7204e-05
-Last step size                = 1.57037
-Current step size             = 3.67703
+Last step size                = 6.26413
+Current step size             = 6.26413
 Last method order             = 2
 Current method order          = 2
 Stab. lim. order reductions   = 0
-RHS fn evals                  = 1381
-NLS iters                     = 1380
-NLS fails                     = 23
-NLS iters per step            = 1.25341
-LS setups                     = 75
-Jac fn evals                  = 16
+RHS fn evals                  = 3802
+NLS iters                     = 3801
+NLS fails                     = 17
+NLS iters per step            = 1.13125
+LS setups                     = 84
+Jac fn evals                  = 18
 LS RHS fn evals               = 0
 Prec setup evals              = 0
 Prec solves                   = 0
@@ -59,7 +59,7 @@ LS fails                      = 0
 Jac-times setups              = 0
 Jac-times evals               = 0
 LS iters per NLS iter         = 0
-Jac evals per NLS iter        = 0.0115942
+Jac evals per NLS iter        = 0.0047356
 Prec evals per NLS iter       = 0
 Root fn evals                 = 0
-   Auto nonlinear solver iteration totals: newton = 295, fixed-point = 1085
+   Auto nonlinear solver iteration totals: newton = 302, fixed-point = 3499


### PR DESCRIPTION
Update output file for llnl/sundials#978